### PR TITLE
Fix: debian compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ DBGCFLAGS = -g -w -fopenmp
 # -lm links the math library
 #LIBS = -lm -lpthread -lz
 LIBS = -lm -pthread -lz -std=gnu99
-OPENMP = -fopenmp -Wno-error=implicit-function-declaration -Wno-error=builtin-declaration-mismatch -w
+OPENMP = -fopenmp -Wno-error=implicit-function-declaration -Wno-error=builtin-declaration-mismatch -Wno-incompatible-pointer-types -Wno-int-conversion -w
 OPTIMIZATION = -O3 -march=native
 #sources
 SOURCES = ancestralclust.c options.c math.c opt.c

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ DBGCFLAGS = -g -w -fopenmp
 # -lm links the math library
 #LIBS = -lm -lpthread -lz
 LIBS = -lm -pthread -lz -std=gnu99
-OPENMP = -fopenmp
+OPENMP = -fopenmp -Wno-error=implicit-function-declaration -Wno-error=builtin-declaration-mismatch -w
 OPTIMIZATION = -O3 -march=native
 #sources
 SOURCES = ancestralclust.c options.c math.c opt.c

--- a/ancestralclust.c
+++ b/ancestralclust.c
@@ -1747,7 +1747,7 @@ int perform_WFA_alignment(cigar_t* const cigar, mm_allocator_t* mm_allocator,cha
 					text_alg[alg_pos++] = seq2[text_pos];
 				}else{
 					pattern_alg[alg_pos] = seq1[pattern_pos];
-					ops_alg[alg_pos] = "|";
+					ops_alg[alg_pos] = '|';
 					text_alg[alg_pos++] = seq2[text_pos];
 				}
 				pattern_pos++; text_pos++;
@@ -5421,7 +5421,7 @@ int main(int argc, char **argv){
 			actualSeqsToPrint[i] = (char *)malloc((fasta_specs[1]+1)*sizeof(char));
 		}
 		if (opt.output_fasta==1){
-			gzFile *fasta_to_assign = gzopen(opt.fasta,"r");
+			gzFile fasta_to_assign = gzopen(opt.fasta,"r");
 			FILE* taxonomy_file;
 			printLessThanFour(fasta_to_assign, numberOfUnAssigned, opt, starting_number_of_clusters, taxonomy_file, fasta_specs[2], fasta_specs[1]+1,sequencesToClusterLater,seqsToPrint,actualSeqsToPrint);
 		}

--- a/global.h
+++ b/global.h
@@ -6,16 +6,16 @@
 #ifndef _GLOBAL_
 #define _GLOBAL_
 
-#define FASTA_MAXLINE 6000
+#define FASTA_MAXLINE 600000
 #define MAXNAME 30
 #define MIN_SEQ 100
 #define MAX_FILENAME 100
 #define DISTMAX 30.0
 #define MINBL 0.00001
 #define MAXBL 2.0
-#define MAXNUMBEROFCLUSTERS 100
-#define MAXNUMBEROFKSEQS 10000
-#define MAXNUMINCLUSTER 10000
+#define MAXNUMBEROFCLUSTERS 10000
+#define MAXNUMBEROFKSEQS 1000000
+#define MAXNUMINCLUSTER 1000000
 #define PADDING 500
 #define MIN_REQ_SSIZE 81920
 #define STATESPACE 20 /*number of categories in approximation of gamma distribution for Ne. Must be at least 4 because some of the memory is used for the nucleotide model*/

--- a/math.c
+++ b/math.c
@@ -1,4 +1,4 @@
-#include "math.h"
+#include <math.h>
 
 double LnGamma (double alpha)
 {

--- a/math.c
+++ b/math.c
@@ -1,4 +1,4 @@
-#include <math.h>
+#include "math.h"
 
 double LnGamma (double alpha)
 {

--- a/math.c
+++ b/math.c
@@ -1,4 +1,7 @@
 #include "math.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
 
 double LnGamma (double alpha)
 {


### PR DESCRIPTION
 - System headers in math.c resolved all implicit function declaration errors
 - Fixed declaration from gzFile * to gzFile
 - Fixed "|" to '|' for char assignment
 - Added comprehensive warning flags to handle Debian compiler strictness
 - Modified `global.h` values to match what we've been using in the Dockerfile:
```
RUN git clone https://github.com/eDNA-Explorer/AncestralClust.git && \
    cd AncestralClust && \
    sed -i 's/#define MAXNUMBEROFCLUSTERS 100/#define MAXNUMBEROFCLUSTERS 10000/' global.h && \
    sed -i 's/#define MAXNUMINCLUSTER 10000/#define MAXNUMINCLUSTER 1000000/' global.h && \
    sed -i 's/#define MAXNUMBEROFKSEQS 10000/#define MAXNUMBEROFKSEQS 1000000/' global.h && \
    sed -i 's/#define FASTA_MAXLINE 6000/#define FASTA_MAXLINE 600000/' global.h && \
    make && mv ancestralclust /usr/local/crux_bin